### PR TITLE
motorRecord.cc: Update limit in controller when MRES is changed

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -2877,6 +2877,8 @@ velcheckB:
             pmr->vmax = temp_dbl;
             db_post_events(pmr, &pmr->vmax, DBE_VAL_LOG);
         }
+        set_dial_highlimit(pmr, pdset);
+        set_dial_lowlimit(pmr, pdset);
         break;
 
         /* new srev: make mres agree */


### PR DESCRIPTION
When MRES is changed, the limits in the controller may need an update. Add calls to set_dial_highlimit/lowlimit when MRES is changed to get the new raw values.